### PR TITLE
Simplify host flow and refresh UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+

--- a/public/host.html
+++ b/public/host.html
@@ -8,7 +8,7 @@
   <link href="/styles.css" rel="stylesheet">
 </head>
 <body>
-<nav class="navbar navbar-dark bg-dark"><div class="container"><span class="navbar-brand">Host · PartyQuiz</span></div></nav>
+<nav class="navbar bg-light border-bottom"><div class="container"><span class="navbar-brand">Host · PartyQuiz</span></div></nav>
 <main class="container py-4">
   <div class="row g-4">
     <div class="col-lg-7">
@@ -27,17 +27,15 @@
 
       <div class="card mt-3"><div class="card-body">
         <div class="d-flex align-items-center mb-2"><h6 class="mb-0">Preguntas</h6>
-          <button class="btn btn-sm btn-outline-info ms-auto" id="btnSample">Cargar ejemplo</button></div>
+          <button class="btn btn-sm btn-outline-secondary ms-auto" id="btnSample">Cargar ejemplo</button></div>
         <textarea id="questions" class="form-control" rows="10" placeholder='[
   {"text":"¿Capital de México?","options":["CDMX","Guadalajara","Monterrey","Puebla"],"answer":0}
 ]'></textarea>
       </div></div>
 
       <div class="card mt-3"><div class="card-body">
-        <div class="d-flex gap-2">
-          <button id="btnStart" class="btn btn-success" disabled>Iniciar pregunta</button>
-          <button id="btnReveal" class="btn btn-outline-light" disabled>Revelar</button>
-          <button id="btnNext" class="btn btn-warning" disabled>Siguiente</button>
+        <div>
+          <button id="btnStart" class="btn btn-primary" disabled>Iniciar juego</button>
         </div>
         <div class="mt-3">
           <div><span id="qIndex" class="badge bg-warning text-dark">0/0</span>
@@ -100,16 +98,14 @@
   }
 
   $('#btnStart').onclick = ()=>{ if(!code) return; s.emit('host:start_question', { code }, (res)=>{ if(!res.ok) alert(res.error); }); };
-  $('#btnReveal').onclick = ()=>{ if(!code) return; s.emit('host:reveal', { code }, (res)=>{ if(!res.ok) alert(res.error); }); };
-  $('#btnNext').onclick = ()=>{ if(!code) return; s.emit('host:start_question', { code }, ()=>{}); };
 
   s.on('room:update', ({ title, players })=>{
     const ul = $('#players'); ul.innerHTML='';
-    players.forEach(p=>{ const li=document.createElement('li'); li.className='list-group-item bg-transparent text-white'; li.textContent=`${p.name}`; ul.appendChild(li); });
+    players.forEach(p=>{ const li=document.createElement('li'); li.className='list-group-item'; li.textContent=`${p.name}`; ul.appendChild(li); });
   });
 
   s.on('game:question', ({ index, total, text, options, timeLimit: tl })=>{
-    timeLimit = tl; $('#btnReveal').disabled=false; $('#btnNext').disabled=true;
+    timeLimit = tl;
     $('#qIndex').textContent = `${index+1}/${total}`;
     $('#qText').textContent = text;
     const ol = $('#qOpts'); ol.innerHTML=''; options.forEach((o,i)=>{ const li=document.createElement('li'); li.textContent=o; ol.appendChild(li); });
@@ -119,14 +115,13 @@
   s.on('game:answered_count', ({ answered, total })=>{ $('#timer').textContent = `${fmtTime(tick)} · ${answered}/${total} respondieron`; });
 
   s.on('game:reveal', ({ correct, scoreboard })=>{
-    $('#btnReveal').disabled=true; $('#btnNext').disabled=false;
     const sb = $('#scoreboard'); sb.innerHTML='';
-    scoreboard.forEach((p,i)=>{ const li=document.createElement('li'); li.className='list-group-item bg-transparent d-flex justify-content-between align-items-center text-white'; li.innerHTML=`<span>${i+1}. ${p.name}</span><span class="badge bg-primary">${p.score}</span>`; sb.appendChild(li); });
+    scoreboard.forEach((p,i)=>{ const li=document.createElement('li'); li.className='list-group-item d-flex justify-content-between align-items-center'; li.innerHTML=`<span>${i+1}. ${p.name}</span><span class="badge bg-primary">${p.score}</span>`; sb.appendChild(li); });
   });
 
   s.on('game:over', ({ podium })=>{
     alert('Juego terminado! Podio:\n' + podium.map((p,i)=> `${i+1}. ${p.name} (${p.score})`).join('\n'));
-    $('#btnReveal').disabled=true; $('#btnNext').disabled=true; $('#btnStart').disabled=false;
+    $('#btnStart').disabled=false;
     $('#qIndex').textContent='0/0'; $('#qText').textContent=''; $('#qOpts').innerHTML=''; $('#timer').textContent='—';
   });
 

--- a/public/player.html
+++ b/public/player.html
@@ -26,7 +26,7 @@
       </div>
       <h4 id="qText" class="mt-2"></h4>
       <div id="opts" class="d-grid gap-2"></div>
-      <div id="feedback" class="mt-2 small text-white-50"></div>
+      <div id="feedback" class="mt-2 small text-muted"></div>
     </div></div>
   </div>
 </main>
@@ -58,7 +58,7 @@
     const opts = $('#opts'); opts.innerHTML='';
     options.forEach((o,i)=>{
       const btn = document.createElement('button');
-      btn.className = 'btn btn-outline-light';
+      btn.className = 'btn btn-outline-primary';
       btn.textContent = o; btn.onclick = ()=>{
         if(answered) return; answered=true; s.emit('player:answer', { code, choice:i }, (res)=>{ if(!res.ok) alert(res.error); });
         $('#feedback').textContent='Respuesta enviada';
@@ -70,7 +70,7 @@
 
   s.on('game:reveal', ({ correct })=>{
     const btns = Array.from(document.querySelectorAll('#opts button'));
-    btns.forEach((b,i)=>{ if(i===correct){ b.classList.remove('btn-outline-light'); b.classList.add('btn-success'); } else { b.classList.add('btn-outline-secondary'); }});
+    btns.forEach((b,i)=>{ if(i===correct){ b.classList.remove('btn-outline-primary'); b.classList.add('btn-success'); } else { b.classList.add('btn-outline-secondary'); }});
   });
 
   s.on('room:closed', ()=>{ alert('La sala se cerró'); location.reload(); });

--- a/public/presenter.html
+++ b/public/presenter.html
@@ -7,28 +7,33 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="/styles.css" rel="stylesheet">
   <style>
-    body { background:#111; color:#eee; }
     .answers-grid { display:grid; grid-template-columns: repeat(2, 1fr); gap:1rem; }
-    .answer { padding:1rem; border-radius:.75rem; border:1px solid rgba(255,255,255,.2); background:rgba(255,255,255,.05); }
-    .answer.correct { background: rgba(25,135,84,.25); border-color: rgba(25,135,84,.6); }
-    .answer.dim { opacity:.5; }
+    .answer { padding:1rem; border-radius:.75rem; border:1px solid #dee2e6; background:#fff; }
+    .answer.correct { background: rgba(25,135,84,.15); border-color: rgba(25,135,84,.5); }
+    .answer.dim { opacity:.6; }
     .confetti { position:fixed; inset:0; pointer-events:none; }
   </style>
 </head>
 <body>
-<nav class="navbar navbar-dark bg-dark border-bottom border-secondary">
+<nav class="navbar bg-light border-bottom">
   <div class="container"><span class="navbar-brand">Presentador · PartyQuiz</span></div>
 </nav>
 
 <main class="container py-4">
+  <div id="joinForm" class="mb-4">
+    <div class="input-group" style="max-width:320px">
+      <input id="joinCode" class="form-control" placeholder="PIN">
+      <button id="btnJoin" class="btn btn-primary">Ver juego</button>
+    </div>
+  </div>
   <!-- Vista de juego en vivo -->
-  <div id="view-live">
+  <div id="view-live" class="d-none">
     <div class="d-flex justify-content-between align-items-center mb-3">
       <div>
         <span id="badgeIndex" class="badge bg-warning text-dark">0/0</span>
         <span id="badgeTimer" class="badge bg-info">—</span>
       </div>
-      <div id="title" class="small text-white-50">—</div>
+      <div id="title" class="small text-muted">—</div>
     </div>
 
     <h2 id="qText" class="mb-3">Esperando pregunta…</h2>
@@ -59,7 +64,7 @@
   const s = io();
   const $ = sel => document.querySelector(sel);
 
-  let timeLimit = 20, tick = 0, timerId = null;
+  let code = null, timeLimit = 20, tick = 0, timerId = null;
 
   function startTimer(t){
     clearInterval(timerId);
@@ -82,7 +87,7 @@
     list.forEach((p,i)=>{
       const row = document.createElement('div');
       row.className = 'd-flex align-items-center gap-2 p-2 rounded';
-      row.style.background = i===0? 'rgba(255,215,0,.08)':'rgba(255,255,255,.04)';
+      row.style.background = i===0? 'rgba(255,215,0,.15)':'rgba(0,0,0,.03)';
       row.innerHTML = `<div style="width:2rem;text-align:center">${i+1}</div>
                        <div class="flex-grow-1">${p.name}</div>
                        <div class="badge bg-secondary">${p.score}</div>`;
@@ -103,6 +108,15 @@
       t++; if(t>500) clearInterval(id);
     },16);
   }
+
+  $('#btnJoin').onclick = ()=>{
+    code = $('#joinCode').value.trim();
+    s.emit('presenter:join', { code }, (res)=>{
+      if(!res.ok) return alert(res.error||'PIN inválido');
+      $('#joinForm').classList.add('d-none');
+      $('#view-live').classList.remove('d-none');
+    });
+  };
 
   // Eventos de juego
   s.on('game:question', ({ index,total,text,options,timeLimit:tl,title })=>{

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,4 +1,4 @@
-body{background:linear-gradient(180deg,#0f1020,#151734); color:#e9ecf1}
-.card{background:rgba(255,255,255,.05); border-color:rgba(255,255,255,.15)}
-.badge-soft{background:rgba(255,255,255,.08); border:1px solid rgba(255,255,255,.1)}
+body{background:#f8f9fa; color:#212529}
+.card{background:#fff; border-color:rgba(0,0,0,.125)}
+.badge-soft{background:#e9ecef; border:1px solid #ced4da}
 .option{cursor:pointer}

--- a/server.js
+++ b/server.js
@@ -136,6 +136,13 @@ io.on('connection', (socket) => {
     io.to(code).emit('room:update', { title: room.title, players: getPublicPlayers(room) });
   });
 
+  socket.on('presenter:join', ({ code }, ack) => {
+    const room = rooms.get(code);
+    if(!room) return ack?.({ ok:false, error:'Sala no encontrada' });
+    socket.join(code);
+    ack?.({ ok:true });
+  });
+
   socket.on('host:start_question', ({ code }, ack) => {
     const room = rooms.get(code);
     if(!room) return ack?.({ ok:false, error:'Sala no encontrada' });
@@ -162,15 +169,6 @@ io.on('connection', (socket) => {
     io.to(code).emit('game:answered_count', { answered: answeredCount, total: room.players.size });
   });
 
-  socket.on('host:reveal', ({ code }, ack) => {
-    const room = rooms.get(code);
-    if(!room) return ack?.({ ok:false, error:'Sala no encontrada' });
-    if(room.hostId !== socket.id) return ack?.({ ok:false, error:'No eres el host' });
-    clearTimers(room);
-    revealAndScore(code);
-    room.nextTimeoutId = setTimeout(() => startNextQuestion(code), 3000);
-    ack?.({ ok:true });
-  });
 
   socket.on('disconnect', () => {
     for(const [code, room] of rooms){


### PR DESCRIPTION
## Summary
- Remove manual reveal/next controls and rely on automatic flow
- Allow presenter clients to join a room and view live quiz
- Apply lighter, neutral styling across all views

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68c653ec05e083228cc6566d71b86857