### PR TITLE
Lock answers and show final ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ npm run start
 
 - Host: http://localhost:3000/host.html
 - Jugador: http://localhost:3000/player.html
+ - Presentador: http://localhost:3000/presenter.xhtml
 
 Para que los móviles de tu red entren, usa `http://TU_IP_LOCAL:3000/player.html`.
 

--- a/public/player.html
+++ b/public/player.html
@@ -29,20 +29,28 @@
       <div id="feedback" class="mt-2 small text-muted"></div>
     </div></div>
   </div>
+
+  <div id="gameOver" class="d-none">
+    <div class="mt-3 card"><div class="card-body text-center">
+      <h4 id="finalMsg" class="mb-3"></h4>
+      <ol id="finalPodium" class="list-group list-group-numbered mb-3 text-start"></ol>
+      <button id="btnFinish" class="btn btn-primary w-100">Finalizar</button>
+    </div></div>
+  </div>
 </main>
 <script src="/socket.io/socket.io.js"></script>
 <script type="module">
   import { connectSocket, fmtTime } from './client.js';
   const s = connectSocket();
   const $ = sel => document.querySelector(sel);
-  let joined=false, code=null, answered=false, tick=0, timerId=null, timeLimit=20;
+  let joined=false, code=null, answered=false, tick=0, timerId=null, timeLimit=20, playerName='';
 
   $('#btnJoin').onclick = ()=>{
     code = $('#code').value.trim(); const name=$('#name').value.trim();
     s.emit('player:join', { code, name }, (res)=>{
       if(!res.ok) return alert(res.error||'No se pudo unir');
       $('#btnJoin').disabled = true; $('#code').disabled = true; $('#name').disabled = true;
-      $('#game').classList.remove('d-none'); joined=true;
+      $('#game').classList.remove('d-none'); joined=true; playerName=name;
     });
   };
 
@@ -60,7 +68,10 @@
       const btn = document.createElement('button');
       btn.className = 'btn btn-outline-primary';
       btn.textContent = o; btn.onclick = ()=>{
-        if(answered) return; answered=true; s.emit('player:answer', { code, choice:i }, (res)=>{ if(!res.ok) alert(res.error); });
+        if(answered) return;
+        answered=true;
+        s.emit('player:answer', { code, choice:i }, (res)=>{ if(!res.ok) alert(res.error); });
+        Array.from(document.querySelectorAll('#opts button')).forEach(b=>b.disabled=true);
         $('#feedback').textContent='Respuesta enviada';
       };
       opts.appendChild(btn);
@@ -72,6 +83,24 @@
     const btns = Array.from(document.querySelectorAll('#opts button'));
     btns.forEach((b,i)=>{ if(i===correct){ b.classList.remove('btn-outline-primary'); b.classList.add('btn-success'); } else { b.classList.add('btn-outline-secondary'); }});
   });
+
+  s.on('game:over', ({ scoreboard })=>{
+    $('#game').classList.add('d-none');
+    const rank = scoreboard.findIndex(p=>p.name===playerName) + 1;
+    const total = scoreboard.length;
+    $('#finalMsg').textContent = `Terminó el juego. Quedaste en el puesto ${rank} de ${total}.`;
+    const pod = $('#finalPodium'); pod.innerHTML='';
+    scoreboard.slice(0,3).forEach((p,i)=>{
+      const li=document.createElement('li');
+      li.className='list-group-item d-flex justify-content-between align-items-center';
+      li.innerHTML=`<span>${p.name}</span><span class="badge bg-primary">${p.score}</span>`;
+      if(p.name===playerName) li.classList.add('active');
+      pod.appendChild(li);
+    });
+    $('#gameOver').classList.remove('d-none');
+  });
+
+  $('#btnFinish').onclick = ()=>{ location.reload(); };
 
   s.on('room:closed', ()=>{ alert('La sala se cerró'); location.reload(); });
 </script>

--- a/public/presenter.xhtml
+++ b/public/presenter.xhtml
@@ -8,9 +8,13 @@
   <link href="/styles.css" rel="stylesheet">
   <style>
     .answers-grid { display:grid; grid-template-columns: repeat(2, 1fr); gap:1rem; }
-    .answer { padding:1rem; border-radius:.75rem; border:1px solid #dee2e6; background:#fff; }
-    .answer.correct { background: rgba(25,135,84,.15); border-color: rgba(25,135,84,.5); }
+    .answer { border:1px solid #dee2e6; border-radius:.75rem; }
+    .answer.correct { border-color: rgba(25,135,84,.5); }
     .answer.dim { opacity:.6; }
+    .answer-0 { background: var(--bs-primary-bg-subtle); }
+    .answer-1 { background: var(--bs-success-bg-subtle); }
+    .answer-2 { background: var(--bs-warning-bg-subtle); }
+    .answer-3 { background: var(--bs-danger-bg-subtle); }
     .confetti { position:fixed; inset:0; pointer-events:none; }
   </style>
 </head>
@@ -129,8 +133,8 @@
     const ans=$('#answers'); ans.innerHTML='';
     options.forEach((o,i)=>{
       const div=document.createElement('div');
-      div.className='answer';
-      div.innerHTML=`<span class="badge bg-primary me-2">${['A','B','C','D'][i]}</span>${o}`;
+      div.className='card answer answer-'+i;
+      div.innerHTML=`<div class="card-body d-flex align-items-center"><span class="badge bg-secondary me-2">${['A','B','C','D'][i]}</span><span>${o}</span></div>`;
       ans.appendChild(div);
     });
   });

--- a/server.js
+++ b/server.js
@@ -71,11 +71,11 @@ function startNextQuestion(code){
   room.revealed = false;
 
   if(room.currentIndex >= room.questions.length){
-    const podium = [...room.players.values()]
+    const scoreboard = [...room.players.values()]
       .sort((a,b)=> b.score - a.score)
-      .slice(0,3)
       .map(p=>({ name:p.name, score:p.score }));
-    io.to(code).emit('game:over', { podium });
+    const podium = scoreboard.slice(0,3);
+    io.to(code).emit('game:over', { podium, scoreboard });
     return;
   }
 


### PR DESCRIPTION
## Summary
- Send final scoreboard and podium from server
- Display final rank and finish button to players
- Style presenter answers as colorful cards and rename to .xhtml

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c656b5ec688322ae16202b2cff4c7f