### PR TITLE
Enhance presenter controls and player option styling

### DIFF
--- a/public/player.html
+++ b/public/player.html
@@ -6,6 +6,16 @@
   <title>PartyQuiz · Player</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="/styles.css" rel="stylesheet">
+  <style>
+    .answers-grid { display:grid; grid-template-columns: repeat(2, 1fr); gap:1rem; }
+    .answer { border:1px solid #dee2e6; border-radius:.75rem; cursor:pointer; }
+    .answer.correct { border-color: rgba(25,135,84,.5); }
+    .answer.dim { opacity:.6; }
+    .answer-0 { background: var(--bs-primary-bg-subtle); }
+    .answer-1 { background: var(--bs-success-bg-subtle); }
+    .answer-2 { background: var(--bs-warning-bg-subtle); }
+    .answer-3 { background: var(--bs-danger-bg-subtle); }
+  </style>
 </head>
 <body>
 <main class="container py-4" style="max-width:540px">
@@ -25,7 +35,7 @@
         <div><span id="badgeTimer" class="badge bg-info">—</span></div>
       </div>
       <h4 id="qText" class="mt-2"></h4>
-      <div id="opts" class="d-grid gap-2"></div>
+      <div id="opts" class="answers-grid"></div>
       <div id="feedback" class="mt-2 small text-muted"></div>
     </div></div>
   </div>
@@ -65,23 +75,24 @@
     $('#qText').textContent = text;
     const opts = $('#opts'); opts.innerHTML='';
     options.forEach((o,i)=>{
-      const btn = document.createElement('button');
-      btn.className = 'btn btn-outline-primary';
-      btn.textContent = o; btn.onclick = ()=>{
+      const div = document.createElement('div');
+      div.className = `card answer answer-${i}`;
+      div.innerHTML = `<div class="card-body">${o}</div>`;
+      div.onclick = ()=>{
         if(answered) return;
         answered=true;
         s.emit('player:answer', { code, choice:i }, (res)=>{ if(!res.ok) alert(res.error); });
-        Array.from(document.querySelectorAll('#opts button')).forEach(b=>b.disabled=true);
+        Array.from(document.querySelectorAll('#opts .answer')).forEach(b=>{b.style.pointerEvents='none';});
         $('#feedback').textContent='Respuesta enviada';
       };
-      opts.appendChild(btn);
+      opts.appendChild(div);
     });
     startTimer(timeLimit);
   });
 
   s.on('game:reveal', ({ correct })=>{
-    const btns = Array.from(document.querySelectorAll('#opts button'));
-    btns.forEach((b,i)=>{ if(i===correct){ b.classList.remove('btn-outline-primary'); b.classList.add('btn-success'); } else { b.classList.add('btn-outline-secondary'); }});
+    const cards = Array.from(document.querySelectorAll('#opts .answer'));
+    cards.forEach((c,i)=>{ if(i===correct){ c.classList.add('correct'); } else { c.classList.add('dim'); }});
   });
 
   s.on('game:over', ({ scoreboard })=>{

--- a/public/presenter.html
+++ b/public/presenter.html
@@ -46,6 +46,13 @@
     <div class="progress mt-4">
       <div id="timeBar" class="progress-bar bg-success" role="progressbar" style="width: 100%"></div>
     </div>
+    <div id="preGame" class="card mt-4">
+      <div class="card-body">
+        <h5 class="mb-3">Jugadores</h5>
+        <ul id="playerList" class="list-group list-group-flush mb-3"></ul>
+        <button id="btnStart" class="btn btn-primary w-100">Iniciar juego</button>
+      </div>
+    </div>
 
     <div class="card mt-4">
       <div class="card-body">
@@ -122,10 +129,20 @@
     });
   };
 
+  $('#btnStart').onclick = ()=>{
+    s.emit('presenter:start', { code }, (res)=>{ if(!res.ok) alert(res.error||'No se pudo iniciar'); });
+  };
+
+  s.on('room:update', ({ players })=>{
+    const ul = $('#playerList'); ul.innerHTML='';
+    players.forEach(p=>{ const li=document.createElement('li'); li.className='list-group-item'; li.textContent=p.name; ul.appendChild(li); });
+  });
+
   // Eventos de juego
   s.on('game:question', ({ index,total,text,options,timeLimit:tl,title })=>{
     $('#view-live').classList.remove('d-none');
     $('#view-podium').classList.add('d-none');
+    $('#preGame').classList.add('d-none');
     timeLimit = tl; startTimer(timeLimit);
     $('#badgeIndex').textContent = (index+1)+'/'+total;
     $('#title').textContent = title;

--- a/server.js
+++ b/server.js
@@ -141,6 +141,14 @@ io.on('connection', (socket) => {
     if(!room) return ack?.({ ok:false, error:'Sala no encontrada' });
     socket.join(code);
     ack?.({ ok:true });
+    socket.emit('room:update', { title: room.title, players: getPublicPlayers(room) });
+  });
+
+  socket.on('presenter:start', ({ code }, ack) => {
+    const room = rooms.get(code);
+    if(!room) return ack?.({ ok:false, error:'Sala no encontrada' });
+    startNextQuestion(code);
+    ack?.({ ok:true });
   });
 
   socket.on('host:start_question', ({ code }, ack) => {


### PR DESCRIPTION
## Summary
- Display player answer options as colorful cards for a cleaner look
- Allow presenter to start the quiz and show joined players
- Support presenter start event on the server and broadcast player updates

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_b_68c65b66b2d08322aaf5a1059666234c