### PR TITLE
feat: allow host to end and reset game

### DIFF
--- a/public/host.html
+++ b/public/host.html
@@ -34,8 +34,9 @@
       </div></div>
 
       <div class="card mt-3"><div class="card-body">
-        <div>
+        <div class="d-flex gap-2">
           <button id="btnStart" class="btn btn-primary" disabled>Iniciar juego</button>
+          <button id="btnEnd" class="btn btn-danger" disabled>Finalizar juego</button>
         </div>
         <div class="mt-3">
           <div><span id="qIndex" class="badge bg-warning text-dark">0/0</span>
@@ -89,6 +90,7 @@
       code = res.code;
       $('#pin').textContent = code;
       $('#btnStart').disabled = false;
+      $('#btnEnd').disabled = false;
     });
   };
 
@@ -98,6 +100,7 @@
   }
 
   $('#btnStart').onclick = ()=>{ if(!code) return; s.emit('host:start_question', { code }, (res)=>{ if(!res.ok) alert(res.error); }); };
+  $('#btnEnd').onclick = ()=>{ if(!code) return; s.emit('host:end_game', { code }, (res)=>{ if(!res.ok) alert(res.error); }); };
 
   s.on('room:update', ({ title, players })=>{
     const ul = $('#players'); ul.innerHTML='';
@@ -106,6 +109,7 @@
 
   s.on('game:question', ({ index, total, text, options, timeLimit: tl })=>{
     timeLimit = tl;
+    $('#btnEnd').disabled = false;
     $('#qIndex').textContent = `${index+1}/${total}`;
     $('#qText').textContent = text;
     const ol = $('#qOpts'); ol.innerHTML=''; options.forEach((o,i)=>{ const li=document.createElement('li'); li.textContent=o; ol.appendChild(li); });
@@ -122,7 +126,9 @@
   s.on('game:over', ({ podium })=>{
     alert('Juego terminado! Podio:\n' + podium.map((p,i)=> `${i+1}. ${p.name} (${p.score})`).join('\n'));
     $('#btnStart').disabled=false;
+    $('#btnEnd').disabled=true;
     $('#qIndex').textContent='0/0'; $('#qText').textContent=''; $('#qOpts').innerHTML=''; $('#timer').textContent='—';
+    $('#scoreboard').innerHTML='';
   });
 
   s.on('room:closed', ()=>{ alert('La sala se cerró (host desconectado)'); location.reload(); });

--- a/public/presenter.html
+++ b/public/presenter.html
@@ -32,6 +32,7 @@
   </div>
   <!-- Vista de juego en vivo -->
   <div id="view-live" class="d-none">
+    <div id="roomCodeDisplay" class="display-1 text-center mb-4"></div>
     <div class="d-flex justify-content-between align-items-center mb-3">
       <div>
         <span id="badgeIndex" class="badge bg-warning text-dark">0/0</span>
@@ -126,6 +127,7 @@
       if(!res.ok) return alert(res.error||'PIN inválido');
       $('#joinForm').classList.add('d-none');
       $('#view-live').classList.remove('d-none');
+      $('#roomCodeDisplay').textContent = code;
     });
   };
 
@@ -143,6 +145,7 @@
     $('#view-live').classList.remove('d-none');
     $('#view-podium').classList.add('d-none');
     $('#preGame').classList.add('d-none');
+    $('#roomCodeDisplay').classList.add('d-none');
     timeLimit = tl; startTimer(timeLimit);
     $('#badgeIndex').textContent = (index+1)+'/'+total;
     $('#title').textContent = title;


### PR DESCRIPTION
## Summary
- allow host to finish current game and reset players for a new round
- show room PIN on presenter view before the game begins

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68c65f16bf6083228aba0ad75d61dcde