### PR TITLE
Add podium medals, QR join link and name filter

### DIFF
--- a/public/player.html
+++ b/public/player.html
@@ -26,6 +26,9 @@
       <div class="col-6"><input id="name" class="form-control" placeholder="Tu nombre"></div>
     </div>
     <button id="btnJoin" class="btn btn-primary mt-3 w-100">Unirse</button>
+    <div id="nameAlert" class="alert alert-warning mt-2 d-none" role="alert">
+      Ese nombre no está permitido. Por favor elige otro.
+    </div>
   </div></div>
 
   <div id="game" class="d-none">
@@ -54,9 +57,19 @@
   const s = connectSocket();
   const $ = sel => document.querySelector(sel);
   let joined=false, code=null, answered=false, tick=0, timerId=null, timeLimit=20, playerName='';
+  const banned = ['puto','puta','cabron','pendejo','ching','verga','coño','culo','mierda','pito','pene','vagina','nalgas'];
+
+  const params = new URLSearchParams(location.search);
+  const codeParam = params.get('code');
+  if(codeParam) $('#code').value = codeParam;
 
   $('#btnJoin').onclick = ()=>{
+    $('#nameAlert').classList.add('d-none');
     code = $('#code').value.trim(); const name=$('#name').value.trim();
+    if(banned.some(w=> name.toLowerCase().includes(w))){
+      $('#nameAlert').classList.remove('d-none');
+      return;
+    }
     s.emit('player:join', { code, name }, (res)=>{
       if(!res.ok) return alert(res.error||'No se pudo unir');
       $('#btnJoin').disabled = true; $('#code').disabled = true; $('#name').disabled = true;

--- a/public/presenter.html
+++ b/public/presenter.html
@@ -16,6 +16,12 @@
     .answer-2 { background: var(--bs-warning-bg-subtle); }
     .answer-3 { background: var(--bs-danger-bg-subtle); }
     .confetti { position:fixed; inset:0; pointer-events:none; }
+    .podium-container { display:flex; justify-content:center; gap:1rem; flex-wrap:wrap; }
+    .podium-step { flex:1 1 100px; text-align:center; padding:1rem; border-radius:.75rem; background:#f8f9fa; }
+    .podium-step.gold { background:linear-gradient(#fff7d1,#ffe066); }
+    .podium-step.silver { background:linear-gradient(#f0f0f0,#d9d9d9); }
+    .podium-step.bronze { background:linear-gradient(#ffe5d0,#d4a373); }
+    .podium-step .medal { font-size:2.5rem; }
   </style>
 </head>
 <body>
@@ -32,7 +38,14 @@
   </div>
   <!-- Vista de juego en vivo -->
   <div id="view-live" class="d-none">
-    <div id="roomCodeDisplay" class="display-1 text-center mb-4"></div>
+    <div id="roomCodeDisplay" class="display-1 text-center mb-2"></div>
+    <div id="joinLinkBox" class="text-center mb-4 d-none">
+      <div id="qrCode" class="mx-auto"></div>
+      <div class="mt-2">
+        <a id="joinLink" href="#" target="_blank"></a>
+        <button id="btnCopyLink" class="btn btn-sm btn-outline-secondary ms-2">Copiar</button>
+      </div>
+    </div>
     <div class="d-flex justify-content-between align-items-center mb-3">
       <div>
         <span id="badgeIndex" class="badge bg-warning text-dark">0/0</span>
@@ -66,16 +79,14 @@
   <!-- Vista de podio -->
   <div id="view-podium" class="d-none">
     <h2 class="mb-4">🏆 ¡Podio!</h2>
-    <ol id="podium" class="list-group list-group-numbered mb-4"></ol>
-    <div id="finalResults" class="d-none">
-      <h3 class="mb-3">Resultados finales</h3>
-      <div id="finalScoreboard" class="d-flex flex-column gap-2"></div>
-    </div>
+    <div id="podium" class="podium-container mb-4"></div>
+    <div id="medalTable" class="mb-4"></div>
     <canvas class="confetti" id="confetti"></canvas>
   </div>
 </main>
 
 <script src="/socket.io/socket.io.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
 <script>
   const s = io();
   const $ = sel => document.querySelector(sel);
@@ -134,6 +145,12 @@
       $('#joinForm').classList.add('d-none');
       $('#view-live').classList.remove('d-none');
       $('#roomCodeDisplay').textContent = code;
+      const joinUrl = `${location.origin}/player.html?code=${code}`;
+      $('#joinLink').href = joinUrl;
+      $('#joinLink').textContent = joinUrl;
+      $('#joinLinkBox').classList.remove('d-none');
+      $('#btnCopyLink').onclick = ()=> navigator.clipboard.writeText(joinUrl);
+      new QRCode(document.getElementById('qrCode'), { text: joinUrl, width:128, height:128 });
     });
   };
 
@@ -153,6 +170,7 @@
     $('#view-podium').classList.add('d-none');
     $('#preGame').classList.add('d-none');
     $('#roomCodeDisplay').classList.add('d-none');
+    $('#joinLinkBox').classList.add('d-none');
     timeLimit = tl; startTimer(timeLimit);
     $('#badgeIndex').textContent = (index+1)+'/'+total;
     $('#title').textContent = title;
@@ -177,22 +195,40 @@
   s.on('game:over', ({ podium,scoreboard })=>{
     $('#view-live').classList.add('d-none');
     $('#view-podium').classList.remove('d-none');
+    const medals=['🥇','🥈','🥉'];
     const pod=$('#podium'); pod.innerHTML='';
     podium.forEach((p,i)=>{
-      const li=document.createElement('li');
-      li.className='list-group-item d-flex justify-content-between align-items-center';
-      li.innerHTML=`<span>${p.name}</span><span class="badge bg-primary">${p.score} pts</span>`;
-      pod.appendChild(li);
+      const div=document.createElement('div');
+      const cls=['gold','silver','bronze'][i];
+      div.className=`podium-step ${cls}`;
+      div.innerHTML=`<div class="medal">${medals[i]}</div><div class="fw-bold">${p.name}</div><div class="small text-muted">${p.score} pts</div>`;
+      pod.appendChild(div);
     });
+    renderMedalTable(scoreboard);
     fireConfetti();
-    setTimeout(()=>{
-      $('#confetti').classList.add('d-none');
-      $('#podium').classList.add('d-none');
-      $('#view-podium h2').textContent = 'Resultados finales';
-      $('#finalResults').classList.remove('d-none');
-      renderScoreboard(scoreboard, true, '#finalScoreboard');
-    },15000);
+    setTimeout(()=>{ $('#confetti').classList.add('d-none'); },15000);
   });
+
+  function renderMedalTable(scoreboard){
+    const data = scoreboard.map((p,i)=>({
+      name:p.name,
+      gold:i===0?1:0,
+      silver:i===1?1:0,
+      bronze:i===2?1:0
+    })).sort((a,b)=> b.gold - a.gold || b.silver - a.silver || b.bronze - a.bronze);
+    const container = $('#medalTable'); container.innerHTML='';
+    const table=document.createElement('table');
+    table.className='table table-striped text-center';
+    table.innerHTML='<thead><tr><th>Jugador</th><th>🥇</th><th>🥈</th><th>🥉</th></tr></thead>';
+    const tbody=document.createElement('tbody');
+    data.forEach(p=>{
+      const tr=document.createElement('tr');
+      tr.innerHTML=`<td class="text-start">${p.name}</td><td>${p.gold}</td><td>${p.silver}</td><td>${p.bronze}</td>`;
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+    container.appendChild(table);
+  }
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- style podium with medal table and gold/silver/bronze highlights on presenter view
- generate QR code and copyable join link for players
- prevent offensive player names with client-side filter

## Testing
- `npm test` (fails: Missing script "test")
- `npm start`

------
https://chatgpt.com/codex/tasks/task_b_68c7095a69c883229930992341f8ea53