### PR TITLE
Rename project to Qwizu with podium ranking

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,8 @@
+Qwizu Educational License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to use the Software for educational, non-commercial purposes within schools.
+
+Any commercial use or use outside of educational institutions is prohibited without prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -1,57 +1,16 @@
-# PartyQuiz (Node.js + Socket.io + Bootstrap 5)
+# Qwizu
 
-Juego tipo Kahoot multijugador para tu grupo de amigos.
+Qwizu es una aplicación de cuestionarios en tiempo real pensada para dinamizar el aprendizaje en el aula.
 
-## Demo local
+## Uso educativo
 
-```bash
-npm install
-npm run start
-```
+Este proyecto está diseñado exclusivamente para actividades escolares y su empleo se limita a fines educativos.
 
-- Host: http://localhost:3000/host.html
-- Jugador: http://localhost:3000/player.html
- - Presentador: http://localhost:3000/presenter.xhtml
+## Nota legal
 
-Para que los móviles de tu red entren, usa `http://TU_IP_LOCAL:3000/player.html`.
+Qwizu es un proyecto independiente y no mantiene relación alguna con Kahoot!, Kahoot! Inc. ni con otras marcas registradas similares.
 
-## Deploy en Render
+## Licencia
 
-1. Sube este repo a GitHub.
-2. En Render, crea un **Web Service** desde tu repo (Build: `npm install`, Start: `node server.js`).
-3. Render asigna `PORT` automáticamente (el servidor ya lo usa).
-4. Abre la URL pública de Render:
-   - Host: `https://tu-app.onrender.com/host.html`
-   - Jugador: `https://tu-app.onrender.com/player.html`
+El software se distribuye bajo la [licencia](LICENSE) incluida en este repositorio, la cual restringe su uso a contextos escolares y no comerciales.
 
-> Socket.io funciona out-of-the-box en Render.
-
-## Estructura
-
-```
-partyquiz/
-├─ package.json
-├─ server.js
-└─ public/
-   ├─ host.html
-   ├─ player.html
-   ├─ styles.css
-   └─ client.js
-```
-
-## Formato de preguntas
-
-```json
-[
-  {
-    "text": "¿Capital de México?",
-    "options": ["Ciudad de México","Guadalajara","Monterrey","Puebla"],
-    "answer": 0
-  }
-]
-```
-
-## Notas
-
-- Estado en memoria (suficiente para partidas casuales). Si escalas, usar Redis/DB.
-- Si usas Nginx como proxy, no olvides `Upgrade`/`Connection: upgrade` para WebSockets.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "partyquiz",
+  "name": "qwizu",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/public/host.html
+++ b/public/host.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>PartyQuiz · Host</title>
+  <title>Qwizu · Host</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="/styles.css" rel="stylesheet">
 </head>
 <body>
-<nav class="navbar bg-light border-bottom"><div class="container"><span class="navbar-brand">Host · PartyQuiz</span></div></nav>
+<nav class="navbar bg-light border-bottom"><div class="container"><span class="navbar-brand">Host · Qwizu</span></div></nav>
 <main class="container py-4">
   <div class="row g-4">
     <div class="col-lg-7">

--- a/public/player.html
+++ b/public/player.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>PartyQuiz · Player</title>
+  <title>Qwizu · Player</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="/styles.css" rel="stylesheet">
   <style>

--- a/public/presenter.html
+++ b/public/presenter.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>PartyQuiz · Presentador</title>
+  <title>Qwizu · Presentador</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="/styles.css" rel="stylesheet">
   <style>
@@ -26,7 +26,7 @@
 </head>
 <body>
 <nav class="navbar bg-light border-bottom">
-  <div class="container"><span class="navbar-brand">Presentador · PartyQuiz</span></div>
+  <div class="container"><span class="navbar-brand">Presentador · Qwizu</span></div>
 </nav>
 
 <main class="container py-4">
@@ -78,9 +78,14 @@
 
   <!-- Vista de podio -->
   <div id="view-podium" class="d-none">
-    <h2 class="mb-4">🏆 ¡Podio!</h2>
-    <div id="podium" class="podium-container mb-4"></div>
-    <div id="medalTable" class="mb-4"></div>
+    <div id="podiumSection">
+      <h2 class="mb-4">🏆 ¡Podio!</h2>
+      <div id="podium" class="podium-container mb-4"></div>
+    </div>
+    <div id="rankingSection" class="d-none">
+      <h2 class="mb-4">📊 Clasificación final</h2>
+      <div id="finalRanking" class="d-flex flex-column gap-2"></div>
+    </div>
     <canvas class="confetti" id="confetti"></canvas>
   </div>
 </main>
@@ -195,6 +200,8 @@
   s.on('game:over', ({ podium,scoreboard })=>{
     $('#view-live').classList.add('d-none');
     $('#view-podium').classList.remove('d-none');
+    $('#podiumSection').classList.remove('d-none');
+    $('#rankingSection').classList.add('d-none');
     const medals=['🥇','🥈','🥉'];
     const pod=$('#podium'); pod.innerHTML='';
     podium.forEach((p,i)=>{
@@ -204,31 +211,14 @@
       div.innerHTML=`<div class="medal">${medals[i]}</div><div class="fw-bold">${p.name}</div><div class="small text-muted">${p.score} pts</div>`;
       pod.appendChild(div);
     });
-    renderMedalTable(scoreboard);
+    renderScoreboard(scoreboard, true, '#finalRanking');
     fireConfetti();
     setTimeout(()=>{ $('#confetti').classList.add('d-none'); },15000);
+    setTimeout(()=>{
+      $('#podiumSection').classList.add('d-none');
+      $('#rankingSection').classList.remove('d-none');
+    },10000);
   });
-
-  function renderMedalTable(scoreboard){
-    const data = scoreboard.map((p,i)=>({
-      name:p.name,
-      gold:i===0?1:0,
-      silver:i===1?1:0,
-      bronze:i===2?1:0
-    })).sort((a,b)=> b.gold - a.gold || b.silver - a.silver || b.bronze - a.bronze);
-    const container = $('#medalTable'); container.innerHTML='';
-    const table=document.createElement('table');
-    table.className='table table-striped text-center';
-    table.innerHTML='<thead><tr><th>Jugador</th><th>🥇</th><th>🥈</th><th>🥉</th></tr></thead>';
-    const tbody=document.createElement('tbody');
-    data.forEach(p=>{
-      const tr=document.createElement('tr');
-      tr.innerHTML=`<td class="text-start">${p.name}</td><td>${p.gold}</td><td>${p.silver}</td><td>${p.bronze}</td>`;
-      tbody.appendChild(tr);
-    });
-    table.appendChild(tbody);
-    container.appendChild(table);
-  }
 </script>
 </body>
 </html>

--- a/render.yaml
+++ b/render.yaml
@@ -1,6 +1,6 @@
 services:
   - type: web
-    name: partyquiz
+    name: qwizu
     env: node
     buildCommand: npm install
     startCommand: node server.js

--- a/server.js
+++ b/server.js
@@ -17,7 +17,7 @@ function createRoom({ title, timeLimit, basePoints, questions, hostSocketId }) {
   const code = genPIN();
   rooms.set(code, {
     code,
-    title: title || 'PartyQuiz',
+    title: title || 'Qwizu',
     timeLimit: Math.max(5, Number(timeLimit)||20),
     basePoints: Math.max(100, Number(basePoints)||1000),
     questions: Array.isArray(questions) ? questions : [],
@@ -210,4 +210,4 @@ io.on('connection', (socket) => {
 });
 
 const PORT = process.env.PORT || 3000;
-server.listen(PORT, () => console.log(`PartyQuiz listo en http://localhost:${PORT}`));
+server.listen(PORT, () => console.log(`Qwizu listo en http://localhost:${PORT}`));


### PR DESCRIPTION
## Summary
- Rebrand project and assets to **Qwizu** including package name, service config and HTML titles.
- Add an educational-use license and initial README highlighting legal notice and school-only usage.
- Enhance presenter: show podium first then switch to full player ranking after 10 seconds.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68c71137bb388322b5ea521909f520fa